### PR TITLE
Porting `ImageClassifier` to `keras_core`

### DIFF
--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -13,6 +13,27 @@
 # limitations under the License.
 
 # isort:off
+import os
+
+_USE_KERAS_CORE = False
+
+if "USE_KERAS_CORE" in os.environ:
+    _USE_KERAS_CORE = True
+
+
+def use_keras_core():
+    return _USE_KERAS_CORE
+
+
+if use_keras_core():
+    import keras_core
+
+    register_keras_serializable = keras_core.saving.register_keras_serializable
+else:
+    from tensorflow import keras
+
+    register_keras_serializable = keras.utils.register_keras_serializable
+
 from keras_cv import version_check
 
 version_check.check_tf_version()

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -15,13 +15,20 @@
 
 import os
 
+from keras_cv import use_keras_core
+
+if use_keras_core():
+    import keras_core
+
 from tensorflow import keras
 
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
 
+base_class = keras_core.Model if use_keras_core() else keras.Model
 
-class Backbone(keras.Model):
+
+class Backbone(base_class):
     """Base class for Backbone models.
 
     Backbones are reusable layers of models trained on a standard task such as
@@ -37,7 +44,6 @@ class Backbone(keras.Model):
         # models is nested and cannot be passed to our Backbone constructors.
         return {
             "name": self.name,
-            "trainable": self.trainable,
         }
 
     @classmethod
@@ -115,12 +121,20 @@ class Backbone(keras.Model):
         if preset not in cls.presets_with_weights or load_weights is False:
             return model
 
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
-        )
+        if use_keras_core():
+            weights = keras_core.utils.file_utils.get_file(
+                "model.h5",
+                metadata["weights_url"],
+                cache_subdir=os.path.join("models", preset),
+                file_hash=metadata["weights_hash"],
+            )
+        else:
+            weights = keras.utils.get_file(
+                "model.h5",
+                metadata["weights_url"],
+                cache_subdir=os.path.join("models", preset),
+                file_hash=metadata["weights_hash"],
+            )
 
         model.load_weights(weights)
         return model

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
@@ -20,9 +20,15 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras_cv import register_keras_serializable
+from keras_cv import use_keras_core
+
+if use_keras_core():
+    from keras_core import backend
+    from keras_core import layers
+else:
+    from keras import backend
+    from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
@@ -221,7 +227,7 @@ def apply_stack(
     return x
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@register_keras_serializable(package="keras_cv.models")
 class ResNetBackbone(Backbone):
     """Instantiates the ResNet architecture.
 
@@ -315,7 +321,9 @@ class ResNetBackbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[stack_index + 2] = x.node.layer.name
+            pyramid_level_inputs[stack_index + 2] = utils.get_tensor_input_name(
+                x
+            )
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for loading pretrained model presets."""
 
+import numpy as np
 import pytest
 import tensorflow as tf
 
@@ -33,7 +34,7 @@ class ResNetPresetSmokeTest(tf.test.TestCase):
     """
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_backbone_output(self):
         model = ResNetBackbone.from_preset("resnet50")
@@ -48,7 +49,7 @@ class ResNetPresetSmokeTest(tf.test.TestCase):
         # We should only update these numbers if we are updating a weights
         # file, or have found a discrepancy with the upstream source.
 
-        outputs = model(tf.ones(shape=(1, 512, 512, 3)))
+        outputs = model(np.ones(shape=(1, 512, 512, 3)))
         expected = [0.0, 0.0, 0.0, 0.05175382, 0.0]
         # Keep a high tolerance, so we are robust to different hardware.
         self.assertAllClose(
@@ -89,7 +90,7 @@ class ResNetPresetFullTest(tf.test.TestCase):
     """
 
     def test_load_resnet(self):
-        input_data = tf.ones(shape=(2, 224, 224, 3))
+        input_data = np.ones(shape=(2, 224, 224, 3))
         for preset in ResNetBackbone.presets:
             model = ResNetBackbone.from_preset(preset)
             model(input_data)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -14,10 +14,19 @@
 
 import os
 
+from keras_cv import use_keras_core
+
+if use_keras_core():
+    from keras_core import Input
+    from keras_core.saving import load_model
+else:
+    from keras.models import load_model
+    from keras import Input
+
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone import (
     ResNet18Backbone,
@@ -39,7 +48,7 @@ from keras_cv.utils.train import get_feature_extractor
 
 class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_valid_call(self):
         model = ResNetBackbone(
@@ -63,12 +72,8 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = ResNetBackbone(
             stackwise_filters=[64, 128, 256, 512],
             stackwise_blocks=[2, 2, 2, 2],
@@ -76,9 +81,14 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
-        restored_model = keras.models.load_model(save_path)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v1_backbone.keras"
+        )
+        if use_keras_core():
+            model.save(save_path)
+        else:
+            model.save(save_path, save_format="keras_v3")
+        restored_model = load_model(save_path)
 
         # Check we got the real object back.
         self.assertIsInstance(restored_model, ResNetBackbone)
@@ -87,17 +97,18 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = ResNet50Backbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
-        restored_model = keras.models.load_model(save_path)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v1_alias_backbone.keras"
+        )
+        if use_keras_core():
+            model.save(save_path)
+        else:
+            model.save(save_path, save_format="keras_v3")
+        restored_model = load_model(save_path)
 
         # Check we got the real object back.
         # Note that these aliases serialized as the base class
@@ -116,15 +127,15 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.values(),
             model.pyramid_level_inputs.keys(),
         )
-        inputs = keras.Input(shape=[256, 256, 3])
+        inputs = Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         # Resnet50 backbone has 4 level of features (2 ~ 5)
         self.assertLen(outputs, 4)
         self.assertEquals(list(outputs.keys()), [2, 3, 4, 5])
-        self.assertEquals(outputs[2].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs[5].shape, [None, 8, 8, 2048])
+        self.assertEquals(outputs[2].shape, (None, 64, 64, 256))
+        self.assertEquals(outputs[3].shape, (None, 32, 32, 512))
+        self.assertEquals(outputs[4].shape, (None, 16, 16, 1024))
+        self.assertEquals(outputs[5].shape, (None, 8, 8, 2048))
 
     def test_create_backbone_model_with_level_config(self):
         model = ResNetBackbone(
@@ -137,12 +148,12 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         levels = [3, 4]
         layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
         backbone_model = get_feature_extractor(model, layer_names, levels)
-        inputs = keras.Input(shape=[256, 256, 3])
+        inputs = Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
         self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
+        self.assertEquals(outputs[3].shape, (None, 32, 32, 512))
+        self.assertEquals(outputs[4].shape, (None, 16, 16, 1024))
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -19,9 +19,15 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras_cv import use_keras_core
+from keras_cv import register_keras_serializable
+
+if use_keras_core():
+    from keras_core import backend
+    from keras_core import layers
+else:
+    from tensorflow.keras import backend
+    from tensorflow.keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
@@ -255,7 +261,7 @@ def apply_stack(
     return x
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@register_keras_serializable(package="keras_cv.models")
 class ResNetV2Backbone(Backbone):
     """Instantiates the ResNetV2 architecture.
 
@@ -356,7 +362,9 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[stack_index + 2] = x.node.layer.name
+            pyramid_level_inputs[stack_index + 2] = utils.get_tensor_input_name(
+                x
+            )
 
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -19,8 +19,8 @@ Reference:
 
 import copy
 
-from keras_cv import use_keras_core
 from keras_cv import register_keras_serializable
+from keras_cv import use_keras_core
 
 if use_keras_core():
     from keras_core import backend

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -14,11 +14,12 @@
 
 import os
 
-import pytest
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import use_keras_core
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNet50V2Backbone,
 )
@@ -26,7 +27,6 @@ from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNetV2Backbone,
 )
 from keras_cv.utils.train import get_feature_extractor
-from keras_cv import use_keras_core
 
 if use_keras_core():
     from keras_core import Input

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -30,10 +30,10 @@ from keras_cv.utils.train import get_feature_extractor
 
 if use_keras_core():
     from keras_core import Input
-    from keras_core import saving
+    from keras_core.saving import load_model
 else:
     from tensorflow.keras import Input
-    from tensorflow.keras import saving
+    from tensorflow.keras.models import load_model
 
 
 class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
@@ -77,7 +77,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         model_output = model(self.input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         model.save(save_path, save_format=save_format)
-        restored_model = saving.load_model(save_path)
+        restored_model = load_model(save_path)
 
         # Check we got the real object back.
         self.assertIsInstance(restored_model, ResNetV2Backbone)
@@ -96,7 +96,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         model_output = model(self.input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         model.save(save_path, save_format=save_format)
-        restored_model = saving.load_model(save_path)
+        restored_model = load_model(save_path)
 
         # Check we got the real object back.
         # Note that these aliases serialized as the base class

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -15,9 +15,9 @@
 import os
 
 import pytest
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNet50V2Backbone,
@@ -26,11 +26,19 @@ from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNetV2Backbone,
 )
 from keras_cv.utils.train import get_feature_extractor
+from keras_cv import use_keras_core
+
+if use_keras_core():
+    from keras_core import Input
+    from keras_core import saving
+else:
+    from tensorflow.keras import Input
+    from tensorflow.keras import saving
 
 
 class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     def test_valid_call(self):
         model = ResNetV2Backbone(
@@ -69,7 +77,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         model_output = model(self.input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         model.save(save_path, save_format=save_format)
-        restored_model = keras.models.load_model(save_path)
+        restored_model = saving.load_model(save_path)
 
         # Check we got the real object back.
         self.assertIsInstance(restored_model, ResNetV2Backbone)
@@ -88,7 +96,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         model_output = model(self.input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         model.save(save_path, save_format=save_format)
-        restored_model = keras.models.load_model(save_path)
+        restored_model = saving.load_model(save_path)
 
         # Check we got the real object back.
         # Note that these aliases serialized as the base class
@@ -107,15 +115,15 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.values(),
             model.pyramid_level_inputs.keys(),
         )
-        inputs = keras.Input(shape=[256, 256, 3])
+        inputs = Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         # Resnet50 backbone has 4 level of features (2 ~ 5)
         self.assertLen(outputs, 4)
         self.assertEquals(list(outputs.keys()), [2, 3, 4, 5])
-        self.assertEquals(outputs[2].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs[5].shape, [None, 8, 8, 2048])
+        self.assertEquals(outputs[2].shape, (None, 64, 64, 256))
+        self.assertEquals(outputs[3].shape, (None, 32, 32, 512))
+        self.assertEquals(outputs[4].shape, (None, 16, 16, 1024))
+        self.assertEquals(outputs[5].shape, (None, 8, 8, 2048))
 
     def test_create_backbone_model_with_level_config(self):
         model = ResNetV2Backbone(
@@ -128,12 +136,12 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         levels = [3, 4]
         layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
         backbone_model = get_feature_extractor(model, layer_names, levels)
-        inputs = keras.Input(shape=[256, 256, 3])
+        inputs = Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
         self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
+        self.assertEquals(outputs[3].shape, (None, 32, 32, 512))
+        self.assertEquals(outputs[4].shape, (None, 16, 16, 1024))
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/classification/image_classifier.py
+++ b/keras_cv/models/classification/image_classifier.py
@@ -15,8 +15,13 @@
 
 import copy
 
-from keras import layers
-from tensorflow import keras
+from keras_cv import use_keras_core
+from keras_cv import register_keras_serializable
+
+if use_keras_core():
+    from keras_core import layers
+else:
+    from keras import layers
 
 from keras_cv.models.backbones.backbone_presets import backbone_presets
 from keras_cv.models.backbones.backbone_presets import (
@@ -29,7 +34,7 @@ from keras_cv.models.task import Task
 from keras_cv.utils.python_utils import classproperty
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@register_keras_serializable(package="keras_cv.models")
 class ImageClassifier(Task):
     """Image classifier with pooling and dense layer prediction head.
 
@@ -114,7 +119,7 @@ class ImageClassifier(Task):
         config = super().get_config()
         config.update(
             {
-                "backbone": keras.layers.serialize(self.backbone),
+                "backbone": layers.serialize(self.backbone),
                 "num_classes": self.num_classes,
                 "pooling": self.pooling,
                 "activation": self.activation,

--- a/keras_cv/models/classification/image_classifier.py
+++ b/keras_cv/models/classification/image_classifier.py
@@ -15,8 +15,8 @@
 
 import copy
 
-from keras_cv import use_keras_core
 from keras_cv import register_keras_serializable
+from keras_cv import use_keras_core
 
 if use_keras_core():
     from keras_core import layers

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -17,6 +17,7 @@
 import os
 
 import pytest
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
@@ -29,7 +30,7 @@ from keras_cv.models.classification.image_classifier import ImageClassifier
 
 class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
         self.dataset = tf.data.Dataset.from_tensor_slices(
             (self.input_batch, tf.one_hot(tf.ones((2,), dtype="int32"), 2))
         ).batch(4)
@@ -109,7 +110,7 @@ class ImageClassifierPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     """
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     @parameterized.named_parameters(
         (

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -16,8 +16,8 @@
 
 import os
 
-import pytest
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -23,9 +23,11 @@ if use_keras_core():
     import keras_core
     from keras_core import layers
     from keras_core.saving import get_registered_object
+    from keras_core.utils.file_utils import get_file
 else:
     from tensorflow.keras import layers
     from tensorflow.keras.utils import get_registered_object
+    from tensorflow.keras.utils import get_file
 
 from keras_cv import register_keras_serializable
 from keras_cv.utils.python_utils import classproperty
@@ -154,7 +156,7 @@ class Task(base_class):
             local_weights_path = "model.weights.h5"
 
         # TODO: implement ``get_file`` in ``keras_core``
-        weights = keras.utils.get_file(
+        weights = get_file(
             local_weights_path,
             metadata["weights_url"],
             cache_subdir=os.path.join("models", preset),

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -15,8 +15,9 @@
 
 import os
 
-from keras_cv import use_keras_core
 from tensorflow import keras
+
+from keras_cv import use_keras_core
 
 if use_keras_core():
     import keras_core
@@ -26,10 +27,9 @@ else:
     from tensorflow.keras import layers
     from tensorflow.keras.utils import get_registered_object
 
+from keras_cv import register_keras_serializable
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
-from keras_cv import register_keras_serializable
-
 
 base_class = keras_core.Model if use_keras_core() else keras.Model
 
@@ -138,9 +138,7 @@ class Task(base_class):
         metadata = cls.presets[preset]
         # Check if preset is backbone-only model
         if preset in cls.backbone_presets:
-            backbone_cls = get_registered_object(
-                metadata["class_name"]
-            )
+            backbone_cls = get_registered_object(metadata["class_name"])
             backbone = backbone_cls.from_preset(preset, load_weights)
             return cls(backbone, **kwargs)
 

--- a/keras_cv/models/utils.py
+++ b/keras_cv/models/utils.py
@@ -14,16 +14,30 @@
 # ==============================================================================
 """Utility functions for models"""
 
-from keras import backend
-from keras import layers
-from tensorflow import keras
+from keras_cv import use_keras_core
+
+if use_keras_core():
+    from keras_core import backend
+    from keras_core import layers
+    from keras_core.backend import is_keras_tensor
+else:
+    from keras import backend
+    from keras import layers
+    from keras.backend import is_keras_tensor
+
+
+def get_tensor_input_name(tensor):
+    if use_keras_core():
+        return tensor._keras_history.operation.name
+    else:
+        return tensor.node.layer.name
 
 
 def parse_model_inputs(input_shape, input_tensor):
     if input_tensor is None:
         return layers.Input(shape=input_shape)
     else:
-        if not keras.backend.is_keras_tensor(input_tensor):
+        if not is_keras_tensor(input_tensor):
             return layers.Input(tensor=input_tensor, shape=input_shape)
         else:
             return input_tensor

--- a/keras_cv/utils/train.py
+++ b/keras_cv/utils/train.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv import use_keras_core
+
+if use_keras_core():
+    from keras_core import Model
+else:
+    from keras import Model
+
 import tensorflow as tf
-from tensorflow import keras
 
 
 def scale_loss_for_distribution(loss_value):
@@ -78,4 +84,4 @@ def get_feature_extractor(model, layer_names, output_keys=None):
         output_keys = layer_names
     items = zip(output_keys, layer_names)
     outputs = {key: model.get_layer(name).output for key, name in items}
-    return keras.Model(inputs=model.inputs, outputs=outputs)
+    return Model(inputs=model.inputs, outputs=outputs)


### PR DESCRIPTION
@ianstenbit

I worked on your ianstenbit#1 patch to port the `ImageClassifier` model to `keras_core`. The tests are passing locally with TensorFlow and Jax backend. It'd be best to do a commit-by-commit review since each commit ports a different component.

Let me know if you had something like this in mind. I am trying to port [this example](https://keras.io/guides/keras_cv/classification_with_keras_cv/) to `keras_core` but it'd require porting the efficient net backbone too. I'll take a shot at it and hopefully get it done by the end of the day.